### PR TITLE
[UPD] ssi_product: selaraskan nama class configurator & sequence menu Configuration

### DIFF
--- a/ssi_product/menu.xml
+++ b/ssi_product/menu.xml
@@ -27,7 +27,7 @@
         id="menu_product_configuration"
         name="Configuration"
         parent="menu_root_product"
-        sequence="99"
+        sequence="999"
     />
 
 <menuitem

--- a/ssi_product/models/mixin_product_category_m2o_configurator.py
+++ b/ssi_product/models/mixin_product_category_m2o_configurator.py
@@ -7,7 +7,15 @@ from odoo import fields, models
 from odoo.addons.ssi_decorator import ssi_decorator
 
 
-class MixinProductCategoryM2OConfigurator(models.AbstractModel):
+class MixinProductCategoryM2oConfigurator(models.AbstractModel):
+    """
+    Provide a configurable Many2one selection of ``product.category``.
+
+    Lets a host model restrict which ``product.category`` records are
+    selectable, either manually, by domain, or by Python code, and
+    inject the corresponding form widget into the host view.
+    """
+
     _name = "mixin.product_category_m2o_configurator"
     _inherit = [
         "mixin.decorator",

--- a/ssi_product/models/mixin_product_pricelist_m2o_configurator.py
+++ b/ssi_product/models/mixin_product_pricelist_m2o_configurator.py
@@ -7,7 +7,15 @@ from odoo import fields, models
 from odoo.addons.ssi_decorator import ssi_decorator
 
 
-class MixinProductPricelistM2OConfigurator(models.AbstractModel):
+class MixinProductPricelistM2oConfigurator(models.AbstractModel):
+    """
+    Provide a configurable Many2one selection of ``product.pricelist``.
+
+    Lets a host model restrict which ``product.pricelist`` records are
+    selectable, either manually, by domain, or by Python code, and
+    inject the corresponding form widget into the host view.
+    """
+
     _name = "mixin.product_pricelist_m2o_configurator"
     _inherit = [
         "mixin.decorator",

--- a/ssi_product/models/mixin_product_product_m2o_configurator.py
+++ b/ssi_product/models/mixin_product_product_m2o_configurator.py
@@ -7,7 +7,15 @@ from odoo import fields, models
 from odoo.addons.ssi_decorator import ssi_decorator
 
 
-class MixinProductProductM2OConfigurator(models.AbstractModel):
+class MixinProductProductM2oConfigurator(models.AbstractModel):
+    """
+    Provide a configurable Many2one selection of ``product.product``.
+
+    Lets a host model restrict which ``product.product`` records are
+    selectable, either manually, by domain, or by Python code, and
+    inject the corresponding form widget into the host view.
+    """
+
     _name = "mixin.product_product_m2o_configurator"
     _inherit = [
         "mixin.decorator",

--- a/ssi_product/models/mixin_product_template_m2o_configurator.py
+++ b/ssi_product/models/mixin_product_template_m2o_configurator.py
@@ -7,7 +7,15 @@ from odoo import fields, models
 from odoo.addons.ssi_decorator import ssi_decorator
 
 
-class MixinProductTemplateM2OConfigurator(models.AbstractModel):
+class MixinProductTemplateM2oConfigurator(models.AbstractModel):
+    """
+    Provide a configurable Many2one selection of ``product.template``.
+
+    Lets a host model restrict which ``product.template`` records are
+    selectable, either manually, by domain, or by Python code, and
+    inject the corresponding form widget into the host view.
+    """
+
     _name = "mixin.product_template_m2o_configurator"
     _inherit = [
         "mixin.decorator",


### PR DESCRIPTION
## Ringkasan

- Ganti nama class Python keempat mixin M2O configurator (`product_category`, `product_pricelist`, `product_product`, `product_template`) dari akhiran `M2O` menjadi `M2o`, mengikuti aturan PascalCase yang diturunkan dari `_name` (`m2o` -> `M2o`).
- Ubah `sequence` menu `Configuration` (`menu_product_configuration`) dari `99` menjadi `999`, mengikuti patokan app root SSI (`Report`/`Reporting` = `998`, `Configuration` = `999`).
- `_name`, `_inherit`, nama field, nama method, dan XML id **tidak** berubah — rename ini aman terhadap data yang sudah ada di database pengguna.
- Tambahkan docstring class pada keempat mixin yang classnya berganti nama (wajib per gerbang pre-commit, karena identifier class-nya tersentuh oleh perubahan ini).

Menutup temuan sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-product-attribute` (16 Agustus 2026): `T-02`..`T-06`.

Closes #26

## Test plan

- [ ] CI `test with Odoo` hijau (modul ter-update tanpa error)
- [ ] Menu `Configuration` tampil sebagai item terbawah pada app root `Product & Pricelist`