### PR TITLE
[UPD] ssi_product: lengkapi docstring model produk

### DIFF
--- a/ssi_product/models/product_brand.py
+++ b/ssi_product/models/product_brand.py
@@ -6,6 +6,15 @@ from odoo import api, fields, models
 
 
 class ProductBrand(models.Model):
+    """
+    Represents a commercial brand that products can be tagged with.
+
+    Extends ``mixin.master_data`` so brands follow the standard
+    master data lifecycle (draft/valid/expired states, sequence,
+    active flag). Products link back to their brand via
+    ``product.template.product_brand_id``.
+    """
+
     _name = "product.brand"
     _inherit = [
         "mixin.master_data",
@@ -15,6 +24,11 @@ class ProductBrand(models.Model):
 
     @api.depends("product_ids")
     def _compute_products_count(self):
+        """Count the products currently tagged with this brand.
+
+        :return: no return value; sets ``products_count`` on each
+            record in ``self`` from the length of ``product_ids``
+        """
         for rec in self:
             rec.products_count = len(rec.product_ids)
 

--- a/ssi_product/models/product_category.py
+++ b/ssi_product/models/product_category.py
@@ -7,6 +7,14 @@ from odoo import fields, models
 
 
 class ProductCategory(models.Model):
+    """
+    Adds an explicit ordering field to ``product.category``.
+
+    Core Odoo does not expose a manual ``sequence`` on product
+    categories; this module adds one so categories can be ordered
+    by the user instead of falling back to name/id ordering.
+    """
+
     _name = "product.category"
     _inherit = "product.category"
     _order = "parent_id, sequence, id"

--- a/ssi_product/models/product_pricelist.py
+++ b/ssi_product/models/product_pricelist.py
@@ -8,10 +8,23 @@ from odoo import api, fields, models
 
 
 class ProductPricelist(models.Model):
+    """
+    Adds a price rule counter and smart-button action to pricelists.
+
+    Lets users see, from the pricelist form, how many pricelist
+    items (price rules) exist and jump straight to them filtered by
+    the current pricelist.
+    """
+
     _inherit = "product.pricelist"
 
     @api.depends("item_ids")
     def _compute_item_count(self):
+        """Count the pricelist items attached to this pricelist.
+
+        :return: no return value; sets ``item_count`` on each record
+            in ``self`` from the length of ``item_ids``
+        """
         for rec in self:
             rec.item_count = len(rec.item_ids)
 
@@ -20,6 +33,15 @@ class ProductPricelist(models.Model):
     )
 
     def action_view_price_rules(self):
+        """Open the price rules (pricelist items) of this pricelist.
+
+        Returns the standard ``product.product_pricelist_item_action``
+        act_window, with its domain narrowed to
+        ``pricelist_id = self.id`` and ``default_pricelist_id`` added
+        to the context so new rules are created for this pricelist.
+
+        :return: dict, the act_window action to display
+        """
         self.ensure_one()
         action = self.env.ref("product.product_pricelist_item_action").read()[0]
         action["domain"] = [("pricelist_id", "=", self.id)]

--- a/ssi_product/models/product_product.py
+++ b/ssi_product/models/product_product.py
@@ -6,10 +6,28 @@ from odoo import models
 
 
 class ProductProduct(models.Model):
+    """
+    Adds brand-aware display names and category-based ordering.
+
+    Reorders the default listing by category first, and overrides
+    ``name_get`` so the product's brand is appended to its display
+    name.
+    """
+
     _inherit = "product.product"
     _order = "categ_id, sequence, default_code, name, id"
 
     def name_get(self):
+        """Append the product brand to the standard display name.
+
+        Overridden so that, when a product has
+        ``product_brand_id`` set, the brand name is shown in
+        parentheses after the name core Odoo would otherwise
+        generate (``"<name> (<brand>)"``). Products without a
+        brand keep core's unmodified result.
+
+        :return: list of ``(id, display_name)`` tuples
+        """
         res = super(ProductProduct, self).name_get()
         res2 = []
         for name_tuple in res:

--- a/ssi_product/models/product_template.py
+++ b/ssi_product/models/product_template.py
@@ -6,6 +6,14 @@ from odoo import fields, models
 
 
 class ProductTemplate(models.Model):
+    """
+    Adds a brand field and brand-aware display names to templates.
+
+    Lets each product template be tagged with a ``product.brand``,
+    and overrides ``name_get`` so the brand is appended to the
+    template's display name.
+    """
+
     _inherit = "product.template"
 
     product_brand_id = fields.Many2one(
@@ -15,6 +23,16 @@ class ProductTemplate(models.Model):
     )
 
     def name_get(self):
+        """Append the product brand to the standard display name.
+
+        Overridden so that, when a template has
+        ``product_brand_id`` set, the brand name is shown in
+        parentheses after the name core Odoo would otherwise
+        generate (``"<name> (<brand>)"``). Templates without a
+        brand keep core's unmodified result.
+
+        :return: list of ``(id, display_name)`` tuples
+        """
         res = super(ProductTemplate, self).name_get()
         res2 = []
         for name_tuple in res:


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring class & method pada lima berkas model modul
`ssi_product` yang ditagih sapuan kepatuhan `audit-sweep.sh 14.0
--repo ssi-product-attribute` (16 Agustus 2026):

- `models/product_brand.py` — class `ProductBrand`, method
  `_compute_products_count`
- `models/product_category.py` — class `ProductCategory`
- `models/product_pricelist.py` — class `ProductPricelist`, method
  `_compute_item_count`, method `action_view_price_rules`
- `models/product_product.py` — class `ProductProduct`, method
  `name_get`
- `models/product_template.py` — class `ProductTemplate`, method
  `name_get`

Tidak ada perubahan perilaku, nama class/method/field, atau tanda
tangan method — `git diff` hanya menambah baris docstring.

Docstring `name_get` menyebutkan format nama yang dihasilkan
(`"<name> (<brand>)"`) dan bedanya dari perilaku inti Odoo.
Docstring `action_view_price_rules` menyebutkan act_window yang
dikembalikan serta domain/context yang dipasang.

Docstring `tests/` dan berkas mixin configurator sengaja tidak
disentuh — ditagih issue saudara (lihat `## Tidak termasuk` di
issue).

Closes #28

## Test plan

- [x] `verify-module.sh ssi_product 14.0` — kesepuluh kunci temuan
      yang ditagih issue ini tidak lagi muncul
- [x] `pre-commit-gate.sh` — GATE OK, 0 pelanggaran baru pada
      keenam validator
- [ ] CI GitHub (unit test yang sudah ada tetap hijau tanpa
      disunting)