### PR TITLE
[UPD] ssi_product - Lengkapi docstring test & ganti invalidate_cache manual dengan auto_refresh

### DIFF
--- a/ssi_product/tests/test_data_product_brand.yaml
+++ b/ssi_product/tests/test_data_product_brand.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Product Brand - Create and verify basic data"
     steps:
@@ -130,11 +133,6 @@ scenarios:
           name: "Product For Brand"
           product_brand_id: "EVAL: registry['brand'].id"
           type: "consu"
-
-      - step: "Invalidate cache after product creation"
-        action: "call"
-        target: "brand"
-        method: "invalidate_cache"
 
       - step: "Assert brand now has 1 product"
         action: "assert"

--- a/ssi_product/tests/test_product_brand.py
+++ b/ssi_product/tests/test_product_brand.py
@@ -9,5 +9,13 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestProductBrand(YamlTransactionCase):
+    """Test ``product.brand`` creation, linking, and computed fields."""
+
     def test_product_brand(self):
+        """Run the product brand scenario.
+
+        Covers brand creation, linking a brand to a product template
+        and its variant, product category sequence, and the computed
+        ``products_count`` field.
+        """
         self.run_yaml_scenario("test_data_product_brand.yaml")


### PR DESCRIPTION
## Ringkasan

Sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-product-attribute` (16 Agustus 2026) menemukan lima pelanggaran pada perkakas uji `ssi_product`:

- Class `TestProductBrand` dan method `test_product_brand()` tidak punya docstring (ditagih validator `module` dan `unit-test` sekaligus).
- Skenario `tests/test_data_product_brand.yaml` masih membersihkan cache secara manual (`invalidate_cache`) alih-alih memakai opsi `auto_refresh` milik DSL `odoo-yaml-test`.

## Perubahan

* Tambah docstring bahasa Inggris (gaya reST, ≤ 79 karakter) untuk `TestProductBrand` dan `test_product_brand()`.
* Ganti step manual `action: call` / `method: invalidate_cache` di `test_data_product_brand.yaml` dengan `options: {auto_refresh: true}` di level file — seluruh assertion yang sudah ada dipertahankan tanpa perubahan.

## Verifikasi

```
#VALIDATOR name=module target=ssi_product series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_product series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#GATE repo=ssi-product-attribute modules=1 failed=0 skipped=0 status=OK
```

Kunci temuan `setiap-class-method-punya-docstring|tests/test_product_brand.py …` dan `tidak-ada-invalidate-cache-manual-pakai-options-auto-refresh|tests/test_data_product_brand.yaml` sudah tidak muncul lagi. Satu peringatan (`!`) yang tersisa pada `validate-unit-test.sh` adalah cakupan `action_view_price_rules` yang secara eksplisit di luar lingkup issue ini (lihat `## Tidak termasuk` pada issue).

Closes #29