### PR TITLE
[UPD] ssi_product: IK & tour product.brand

### DIFF
--- a/ssi_product/README.rst
+++ b/ssi_product/README.rst
@@ -7,6 +7,14 @@ Product App
 ===========
 
 
+Work Instruction
+================
+
+* `Create Product Brand <docs/product_brand/index.html>`_
+* `Edit Product Brand <docs/product_brand/index.html>`_
+* `Delete Product Brand <docs/product_brand/index.html>`_
+
+
 Installation
 ============
 

--- a/ssi_product/__manifest__.py
+++ b/ssi_product/__manifest__.py
@@ -11,6 +11,7 @@
     "application": True,
     "depends": [
         "product",
+        "web_tour",
         "ssi_decorator",
         "ssi_master_data_mixin",
     ],
@@ -33,6 +34,7 @@
         "views/product_attribute_views.xml",
         "views/product_supplierinfo_views.xml",
         "views/product_brand_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
 }

--- a/ssi_product/docs/product_brand/01-create.md
+++ b/ssi_product/docs/product_brand/01-create.md
@@ -1,0 +1,51 @@
+# Create Product Brand
+
+> **Module:** ssi_product
+>
+> **Model:** `product.brand`
+>
+> **Menu:** Product & Pricelist > Configuration > Product Categories & Attributes >
+> Product Brands
+>
+> **Actor:** user in group _Product Brand_
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Access:** User is in group _Product Brand_.
+- **Config:** An active `sequence.template` for `product.brand` exists if the code is to
+  be assigned automatically by **Generate Code**. Without it the code has to be typed by
+  hand.
+
+## Flow
+
+1. Open the **Product & Pricelist > Configuration > Product Categories & Attributes >
+   Product Brands** menu. The brands are displayed as kanban cards.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name** _(required)_: Enter the brand name as it should appear on products.
+   - **Code** _(required)_: Enter a unique code for this brand, or enter **/** to leave
+     it eligible for automatic assignment via **Generate Code**.
+   - **Logo File** (on the **Image** tab): Optional. Upload the image shown on the brand
+     kanban card.
+4. Open the **Note** tab and fill in **Note** with a short description of the brand. The
+   kanban card shows the first 200 characters of this text.
+5. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model. Only applies while **Code** is still
+   **/**; otherwise the code stays exactly as typed.
+6. No `sequence.template` is currently configured for **Product Brand**, so a warning
+   dialog appears instead of a new code being assigned. Click **OK** to dismiss it.
+   **Code** remains **/**.
+7. Click **Save**.
+
+## Post-Condition
+
+- A new product brand record is created and active.
+- The new brand appears in the **Product Brands** kanban view.
+- The brand becomes selectable as **Brand** on product templates and their variants.
+
+## Related Views
+
+- The **Products** smart button in the button box opens the list of product templates
+  that carry this brand. It only navigates — it changes nothing on the brand itself.

--- a/ssi_product/docs/product_brand/02-edit.md
+++ b/ssi_product/docs/product_brand/02-edit.md
@@ -1,0 +1,46 @@
+# Edit Product Brand
+
+> **Module:** ssi_product
+>
+> **Model:** `product.brand`
+>
+> **Menu:** Product & Pricelist > Configuration > Product Categories & Attributes >
+> Product Brands
+>
+> **Actor:** user in group _Product Brand_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Record:** The brand to edit already exists.
+- **Access:** User is in group _Product Brand_.
+- **Config:** An active `sequence.template` for `product.brand` exists if **Generate
+  Code** is to assign a code. Without it the code has to be typed by hand.
+
+## Flow
+
+1. Open the **Product & Pricelist > Configuration > Product Categories & Attributes >
+   Product Brands** menu.
+2. Find and open the brand card to edit.
+3. Click the **Edit** button.
+4. Change **Name**, **Code**, **Active**, **Logo File**, or **Note** as needed.
+5. In the header, click **Generate Code** to assign a code from the sequence configured
+   by an active `sequence.template` for this model — for example after setting **Code**
+   back to **/**. Only applies while **Code** is **/**.
+6. No `sequence.template` is currently configured for **Product Brand**, so a warning
+   dialog appears instead of a new code being assigned. Click **OK** to dismiss it.
+   **Code** is left unchanged.
+7. Click **Save**.
+
+## Post-Condition
+
+- The brand is updated with the new values.
+- The updated brand appears with its new name in the **Product Brands** kanban view.
+
+## Related Views
+
+- The **Products** smart button in the button box opens the list of product templates
+  that carry this brand. It only navigates — it changes nothing on the brand itself.

--- a/ssi_product/docs/product_brand/03-delete.md
+++ b/ssi_product/docs/product_brand/03-delete.md
@@ -1,0 +1,34 @@
+# Delete Product Brand
+
+> **Module:** ssi_product
+>
+> **Model:** `product.brand`
+>
+> **Menu:** Product & Pricelist > Configuration > Product Categories & Attributes >
+> Product Brands
+>
+> **Actor:** user in group _Product Brand_
+>
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The brand to delete already exists.
+- **Record:** No product template still refers to this brand — the **Products** smart
+  button shows **0**.
+- **Access:** User is in group _Product Brand_.
+
+## Flow
+
+1. Open the **Product & Pricelist > Configuration > Product Categories & Attributes >
+   Product Brands** menu.
+2. Open the brand card to delete.
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+5. Click the **Brand** breadcrumb link to return to the kanban view.
+
+## Post-Condition
+
+- The brand is permanently removed from the system.
+- The deleted brand no longer appears in the **Product Brands** kanban view.
+- The brand is no longer selectable as **Brand** on product templates.

--- a/ssi_product/static/tests/tours/product_brand_tour.js
+++ b/ssi_product/static/tests/tours/product_brand_tour.js
@@ -1,0 +1,300 @@
+odoo.define("ssi_product.product_brand_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared opening steps for every IK in this file: "Product & Pricelist >
+    // Configuration > Product Categories & Attributes > Product Brands".
+    // "Product Categories & Attributes" (menu_category_root) sits at level 3
+    // and has children of its own, so 14.0 renders it as a non-clickable
+    // dropdown header without [data-menu-xmlid] and flattens its children
+    // into the level-2 "Configuration" dropdown — there is no step for it
+    // (patterns.md "Jumlah level menu di IK != jumlah step tour").
+    //
+    // The gate names the TARGET action ("Brand"); the app landing action is
+    // "Products", which does not contain "Brand", so there is no substring
+    // clash. action_product_brand opens in KANBAN mode (view_mode
+    // "kanban,tree,form"), hence .o_kanban_view rather than .o_list_view.
+    function openProductBrandMenuSteps() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Product & Pricelist app",
+                trigger: '.o_app[data-menu-xmlid="ssi_product.menu_root_product"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.menu_product_configuration"]',
+            },
+            {
+                content: "Open the Product Brands menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.menu_product_brand"]',
+            },
+            {
+                content: "Product Brands kanban is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Brand)",
+                extra_trigger: ".o_kanban_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/product_brand/01-create.md
+    tour.register(
+        "ssi_product_product_brand_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openProductBrandMenuSteps(), [
+            // -- Flow 2 -- Click the New button. (14.0: "Create")
+            {
+                content: "Click Create",
+                trigger: ".o-kanban-button-new",
+                extra_trigger: ".o_kanban_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 3 -- Fill in the required fields. The optional Logo File
+            // on the Image tab is skipped: uploading a real file through a
+            // hidden <input type="file"> is not reliable in a tour
+            // (patterns.md section Q).
+            {
+                content: "Fill in Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Brand Create",
+            },
+            {
+                content: "Fill in Code",
+                trigger: ".o_field_widget[name='code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text /",
+            },
+
+            // -- Flow 4 -- Open the Note tab and fill in Note.
+            {
+                content: "Open the Note tab",
+                trigger: ".o_notebook .nav-link:contains(Note)",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+            {
+                content: "Fill in Note",
+                trigger: ".o_field_widget[name='note']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Brand Create note.",
+            },
+
+            // -- Flow 5 -- Click Generate Code in the header.
+            {
+                content: "Click Generate Code",
+                trigger: ".o_statusbar_buttons button[name='action_generate_code']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // -- Flow 6 -- No sequence.template is configured for product.brand,
+            // so a warning dialog appears instead of a new code. Click OK.
+            {
+                content: "Dismiss the missing sequence.template warning",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // -- Flow 7 -- Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+                extra_trigger: "body:not(:has(.modal))",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Post-Condition -- the new brand appears in the kanban view.
+            {
+                content: "Click the Brand breadcrumb to go back to the kanban",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Brand)",
+            },
+            {
+                content: "New brand is displayed in the kanban view",
+                trigger: ".o_kanban_record:contains(TOUR Brand Create)",
+                extra_trigger: ".o_kanban_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/product_brand/02-edit.md
+    tour.register(
+        "ssi_product_product_brand_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openProductBrandMenuSteps(), [
+            // -- Flow 2 -- Find and open the brand card to edit.
+            {
+                content: "Open the brand card",
+                trigger: ".o_kanban_record:contains(TOUR Brand Edit)",
+                extra_trigger: ".o_kanban_view",
+            },
+            {
+                content: "Form is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 3 -- Click the Edit button.
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 4 -- Change Name.
+            {
+                content: "Change the Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Brand Edited",
+            },
+
+            // -- Flow 5 -- Click Generate Code in the header.
+            {
+                content: "Click Generate Code",
+                trigger: ".o_statusbar_buttons button[name='action_generate_code']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // -- Flow 6 -- No sequence.template is configured for product.brand,
+            // so a warning dialog appears instead of a new code. Click OK.
+            {
+                content: "Dismiss the missing sequence.template warning",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // -- Flow 7 -- Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+                extra_trigger: "body:not(:has(.modal))",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Post-Condition -- the updated brand appears in the kanban view.
+            {
+                content: "Click the Brand breadcrumb to go back to the kanban",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Brand)",
+            },
+            {
+                content: "Updated brand is displayed in the kanban view",
+                trigger: ".o_kanban_record:contains(TOUR Brand Edited)",
+                extra_trigger: ".o_kanban_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/product_brand/03-delete.md
+    tour.register(
+        "ssi_product_product_brand_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(openProductBrandMenuSteps(), [
+            // -- Flow 2 -- Open the brand card to delete.
+            {
+                content: "Open the brand card",
+                trigger: ".o_kanban_record:contains(TOUR Brand Delete)",
+                extra_trigger: ".o_kanban_view",
+            },
+            {
+                content: "Form is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 3 -- Click Action > Delete.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                // Action menu items are Owl components; match the exact label
+                // so ":contains(Delete)" never picks "Archive" instead.
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // -- Flow 4 -- Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // -- Flow 5 -- Click the Brand breadcrumb to return to the kanban.
+            {
+                content: "Click the Brand breadcrumb",
+                trigger: ".breadcrumb-item.o_back_button a:contains(Brand)",
+                extra_trigger: "body:not(:has(.modal))",
+            },
+
+            // -- Post-Condition -- the deleted brand no longer appears.
+            {
+                content: "Deleted brand no longer appears in the kanban view",
+                trigger:
+                    ".o_kanban_view:not(:has(.o_kanban_record:contains(TOUR Brand Delete)))",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_product/tests/__init__.py
+++ b/ssi_product/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_product_brand
+from . import test_ui_product_brand

--- a/ssi_product/tests/test_ui_product_brand.py
+++ b/ssi_product/tests/test_ui_product_brand.py
@@ -1,0 +1,67 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — NOT HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiProductBrand(HttpSavepointCase):
+    """Tour tests for the ``product.brand`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the ``product.brand`` fixtures each tour needs.
+
+        ``ssi_product.product_brand_group`` already grants
+        ``base.user_root`` and ``base.user_admin`` membership in
+        ``security/res_group_data.xml``, so ``admin`` reaches the Product
+        Brands menu without any extra group setup.
+
+        ``note`` is filled deliberately: the brand kanban card renders
+        ``record.note.value.substr(0, 200)``, and 14.0 leaves
+        ``record.note.value`` undefined when the field is empty, which
+        breaks the kanban template the tours navigate through.
+        """
+        super().setUpClass()
+        cls.brand_edit = cls.env["product.brand"].create(
+            {
+                "name": "TOUR Brand Edit",
+                "code": "/",
+                "note": "Tour fixture for the edit work instruction.",
+            }
+        )
+        cls.brand_delete = cls.env["product.brand"].create(
+            {
+                "name": "TOUR Brand Delete",
+                "code": "/",
+                "note": "Tour fixture for the delete work instruction.",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``product.brand``.
+
+        The optional Logo File on the Image tab is asserted by neither the
+        tour nor this test: uploading a real file through a hidden
+        ``<input type="file">`` has no reliable DOM completion signal.
+
+        IK: docs/product_brand/01-create.md
+        """
+        self.start_tour("/web", "ssi_product_product_brand_create", login="admin")
+
+    def test_edit(self):
+        """Run the edit tour for ``product.brand``.
+
+        IK: docs/product_brand/02-edit.md
+        """
+        self.start_tour("/web", "ssi_product_product_brand_edit", login="admin")
+
+    def test_delete(self):
+        """Run the delete tour for ``product.brand``.
+
+        IK: docs/product_brand/03-delete.md
+        """
+        self.start_tour("/web", "ssi_product_product_brand_delete", login="admin")

--- a/ssi_product/views/assets.xml
+++ b/ssi_product/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_product assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_product/static/tests/tours/product_brand_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
Menambahkan Instruksi Kerja (IK) dan UI test (tour) untuk model `product.brand`
di modul `ssi_product`.

## Perubahan

* `docs/product_brand/01-create.md`, `02-edit.md`, `03-delete.md` — masing-masing
  berstruktur Pre-Condition / Flow / Post-Condition, lengkap dengan blok metadata.
  `action_generate_code` dideklarasikan sebagai aksi inline (`Inline Actions:`) pada
  IK create & edit; smart button **Products** dicatat sebagai `## Related Views`
  (navigasi murni).
* `static/tests/tours/product_brand_tour.js` — satu tour per berkas IK
  (`ssi_product_product_brand_create` / `_edit` / `_delete`), langkah Flow dipetakan
  1:1, API tour legacy 14.0.
* `tests/test_ui_product_brand.py` — `HttpSavepointCase` pemanggil ketiga tour.
* `views/assets.xml` — pendaftaran tour ke bundle `web.assets_tests`; `web_tour`
  ditambahkan ke `depends`.
* `README.rst` — bagian `Work Instruction`.

Tidak ada test/tour/assertion yang dihapus, di-skip, atau dilonggarkan.

## Gerbang & validator

```
#GATE repo=ssi-product-attribute modules=1 failed=0 skipped=0 status=OK
#VALIDATOR name=ik   target=.../ssi_product series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=.../ssi_product series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Peringatan tersisa pada validator `ik` (`action_view_price_rules` tanpa rumah di
`docs/`) adalah warisan milik `product.pricelist` — di luar lingkup issue ini.

Closes #30