### PR TITLE
[UPD] ssi_product: IK extension & tour model produk yang di-extend

### DIFF
--- a/ssi_product/README.rst
+++ b/ssi_product/README.rst
@@ -13,6 +13,10 @@ Work Instruction
 * `Create Product Brand <docs/product_brand/index.html>`_
 * `Edit Product Brand <docs/product_brand/index.html>`_
 * `Delete Product Brand <docs/product_brand/index.html>`_
+* `Create Product Category <docs/product_category/index.html>`_
+* `Create Product <docs/product_template/index.html>`_
+* `Create Product Variant <docs/product_product/index.html>`_
+* `View Price Rules of a Pricelist <docs/product_pricelist/index.html>`_
 
 
 Installation

--- a/ssi_product/docs/product_category/01-create.md
+++ b/ssi_product/docs/product_category/01-create.md
@@ -1,0 +1,43 @@
+# Create Product Category
+
+> **Module:** ssi_product
+>
+> **Extends:** `product` (Odoo core) — model `product.category`
+>
+> **Model:** `product.category`
+>
+> **Menu:** Product & Pricelist > Configuration > Product Categories & Attributes >
+> Categories
+>
+> **Actor:** user in group _Product Category_
+
+This work instruction documents only what `ssi_product` adds to `product.category`: the
+manual **Sequence** field. Everything else on this form is core Odoo behaviour and is
+not repeated here.
+
+## Pre-Condition
+
+- **Access:** User is in group _Product Category_.
+- **Module:** `ssi_product` is installed — without it `product.category` has no
+  **Sequence** field and the list has no drag handle.
+
+## Flow
+
+1. Open the **Product & Pricelist > Configuration > Product Categories & Attributes >
+   Categories** menu. The categories are displayed as a list whose first column is the
+   drag handle added by this module.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Category name** _(required)_: Enter the name of the category.
+   - **Sequence** _(required)_: Added by this module. Enter the ordering number of this
+     category among its siblings. It defaults to **4**; a lower number puts the category
+     earlier in every list of categories.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new product category record is created.
+- The category is ordered by its **Sequence** value within its parent category — the
+  model is ordered by `parent_id, sequence, id` once this module is installed.
+- The **Sequence** value can afterwards be changed by dragging the handle in the
+  category list instead of opening the form.

--- a/ssi_product/docs/product_pricelist/04-view-price-rules.md
+++ b/ssi_product/docs/product_pricelist/04-view-price-rules.md
@@ -1,0 +1,39 @@
+# View Price Rules of a Pricelist
+
+> **Module:** ssi_product
+>
+> **Extends:** `product` (Odoo core) — model `product.pricelist`
+>
+> **Model:** `product.pricelist`
+>
+> **Menu:** Product & Pricelist > Pricelist > Pricelists
+>
+> **Actor:** user in group _Pricelist_
+
+This work instruction documents only what `ssi_product` adds to `product.pricelist`: the
+**Price Rules** smart button (`action_view_price_rules`) and the rule counter it
+displays. Everything else on this form is core Odoo behaviour and is not repeated here.
+
+## Pre-Condition
+
+- **Record:** The pricelist to inspect already exists.
+- **Access:** User is in group _Pricelist_.
+- **Module:** `ssi_product` is installed — without it the pricelist form has no button
+  box and no **Price Rules** button.
+
+## Flow
+
+1. Open the **Product & Pricelist > Pricelist > Pricelists** menu. The pricelists are
+   displayed as a list.
+2. Open the pricelist whose price rules are to be inspected.
+3. In the button box at the top of the form, read the **Price Rules** button. The number
+   above its label is the count of price rules currently attached to this pricelist.
+4. Click the **Price Rules** button (`action_view_price_rules`).
+
+## Post-Condition
+
+- The **Price Rules** list opens, restricted to the price rules of the pricelist the
+  button was clicked from.
+- A price rule created from this list is attached to that same pricelist by default.
+- The search panel of that list additionally offers **Product**, **Product Template**,
+  and **Product Category** as search fields — they are added by this module.

--- a/ssi_product/docs/product_product/01-create.md
+++ b/ssi_product/docs/product_product/01-create.md
@@ -1,0 +1,53 @@
+# Create Product Variant
+
+> **Module:** ssi_product
+>
+> **Extends:** `product` (Odoo core) — model `product.product`
+>
+> **Model:** `product.product`
+>
+> **Menu:** Product & Pricelist > Product Varians
+>
+> **Actor:** user in group _Product_
+
+This work instruction documents only what `ssi_product` adds to `product.product`: the
+drag handle and the **Brand** column in the variant list, and the **Brand** and
+**Sequence** fields on the variant form. Everything else on this form is core Odoo
+behaviour and is not repeated here.
+
+## Pre-Condition
+
+- **Access:** User is in group _Product_.
+- **Data:** The brand to select already exists as a `product.brand` record. Create it
+  first through **Configuration > Product Categories & Attributes > Product Brands**
+  (see `docs/product_brand/01-create.md`).
+- **Module:** `ssi_product` is installed — without it the variant list has no **Brand**
+  column and the variant form has no **Brand** field.
+
+## Flow
+
+1. Open the **Product & Pricelist > Product Varians** menu. The variant list is
+   displayed with the drag handle and the **Brand** column added by this module.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields on the **General Information** tab:
+   - **Product Name** _(required)_: Enter the name of the variant.
+   - **Brand**: Added by this module. Select the `product.brand` this variant belongs
+     to. Leaving it empty is allowed; when it is set, the brand is appended to the
+     variant's display name wherever the variant is selected.
+   - **Sequence**: Added to this form by this module. Enter the ordering number used
+     when the variant is displayed in a list.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new product variant record is created and its **Brand** is shown on the saved form.
+- The variant is listed with its brand in the **Brand** column of the variant list.
+- Variants are ordered by category first, then by **Sequence** — the model is ordered by
+  `categ_id, sequence, default_code, name, id` once this module is installed, and the
+  order can afterwards be changed by dragging the handle in the variant list.
+
+## Related Views
+
+- On the variant kanban card, the **Brand** value is rendered as a link that opens the
+  `product.brand` record of that variant. It only navigates — it changes nothing on the
+  variant itself.

--- a/ssi_product/docs/product_template/01-create.md
+++ b/ssi_product/docs/product_template/01-create.md
@@ -1,0 +1,52 @@
+# Create Product
+
+> **Module:** ssi_product
+>
+> **Extends:** `product` (Odoo core) — model `product.template`
+>
+> **Model:** `product.template`
+>
+> **Menu:** Product & Pricelist > Products
+>
+> **Actor:** user in group _Product_
+
+This work instruction documents only what `ssi_product` adds to `product.template`: the
+**Brand** and **Sequence** fields on the product form, the **Brand** column in the
+product list, and the **Brand** grouping in the search panel. Everything else on this
+form is core Odoo behaviour and is not repeated here.
+
+## Pre-Condition
+
+- **Access:** User is in group _Product_.
+- **Data:** The brand to select already exists as a `product.brand` record. Create it
+  first through **Configuration > Product Categories & Attributes > Product Brands**
+  (see `docs/product_brand/01-create.md`).
+- **Module:** `ssi_product` is installed — without it the product form has no **Brand**
+  field.
+
+## Flow
+
+1. Open the **Product & Pricelist > Products** menu. The product list is displayed with
+   the **Brand** column added by this module.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields on the **General Information** tab:
+   - **Product Name** _(required)_: Enter the name of the product.
+   - **Brand**: Added by this module. Select the `product.brand` this product belongs
+     to. Leaving it empty is allowed; when it is set, the brand is appended to the
+     product's display name wherever the product is selected.
+   - **Sequence**: Added to this form by this module. Enter the ordering number used
+     when the product is displayed in a list.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new product record is created and its **Brand** is shown on the saved form.
+- The product is listed with its brand in the **Brand** column of the product list.
+- The product can be grouped by brand through the **Brand** entry of the search panel's
+  **Group By** menu.
+
+## Related Views
+
+- On the product kanban card, the **Brand** value is rendered as a link that opens the
+  `product.brand` record of that product. It only navigates — it changes nothing on the
+  product itself.

--- a/ssi_product/static/tests/tours/product_category_tour.js
+++ b/ssi_product/static/tests/tours/product_category_tour.js
@@ -1,0 +1,115 @@
+odoo.define("ssi_product.product_category_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/product_category/01-create.md
+    //
+    // Menu path in the IK is "Product & Pricelist > Configuration > Product
+    // Categories & Attributes > Categories", but "Product Categories &
+    // Attributes" (menu_category_root) sits at level 3 and has children of its
+    // own, so 14.0 renders it as a non-clickable dropdown header without
+    // [data-menu-xmlid] and flattens its children into the level-2
+    // "Configuration" dropdown — there is no step for it (patterns.md
+    // "Jumlah level menu di IK != jumlah step tour").
+    //
+    // The gate names the TARGET action ("Product Categories"); the app landing
+    // action is "Products", which does not contain that string, so the gate
+    // cannot pass on the previous screen.
+    tour.register(
+        "ssi_product_product_category_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // -- Flow 1 -- Open the Categories menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Product & Pricelist app",
+                trigger: '.o_app[data-menu-xmlid="ssi_product.menu_root_product"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.menu_product_configuration"]',
+            },
+            {
+                content: "Open the Categories menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.product_category_menu"]',
+            },
+            {
+                content: "Product Categories list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active" +
+                    ":contains(Product Categories)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 2 -- Click the New button. (14.0: "Create")
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 3 -- Fill in Category name and the Sequence field this
+            // module adds.
+            {
+                content: "Fill in Category name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Category",
+            },
+            {
+                content: "The Sequence field added by this module is displayed",
+                // Anchor on the label, which always carries text; the input
+                // itself would be an empty-looking box in readonly renders
+                // (patterns.md section O).
+                trigger: ".o_form_label:contains(Sequence)",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+            {
+                content: "Fill in Sequence",
+                trigger: ".o_field_widget[name='sequence']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text 7",
+            },
+
+            // -- Flow 4 -- Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // -- Post-Condition -- the category record exists. Its ordering is
+            // a computed effect of the Sequence value, which is unit test
+            // territory, so the tour stops at the saved record.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                extra_trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(TOUR Category)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_product/static/tests/tours/product_pricelist_tour.js
+++ b/ssi_product/static/tests/tours/product_pricelist_tour.js
@@ -1,0 +1,100 @@
+odoo.define("ssi_product.product_pricelist_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/product_pricelist/04-view-price-rules.md
+    //
+    // "Pricelist" (menu_pricelist_root) has children but sits at level 2, so
+    // 14.0 renders it as a clickable dropdown toggle that keeps its
+    // [data-menu-xmlid] — unlike a level-3 grouping menu, it IS a step. Its
+    // child "Pricelists" (product_pricelist_menu) is a leaf and is the next
+    // step.
+    //
+    // action_view_price_rules is type="object", so button[name='...'] matches
+    // it (selectors.md section 4); the numeric-id caveat only applies to
+    // type="action" buttons.
+    tour.register(
+        "ssi_product_product_pricelist_view_price_rules",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // -- Flow 1 -- Open the Pricelists menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Product & Pricelist app",
+                trigger: '.o_app[data-menu-xmlid="ssi_product.menu_root_product"]',
+            },
+            {
+                content: "Open the Pricelist menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.menu_pricelist_root"]',
+            },
+            {
+                content: "Open the Pricelists menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.product_pricelist_menu"]',
+            },
+            {
+                content: "Pricelists list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Pricelists)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 2 -- Open the pricelist to inspect.
+            {
+                content: "Open the pricelist",
+                trigger: ".o_data_row:contains(TOUR Pricelist) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Pricelist form is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 3 -- Read the Price Rules button in the button box. Its
+            // label is always rendered, so it is a safe anchor; the counter
+            // above it is a computed value and belongs to the unit test.
+            {
+                content: "The Price Rules button added by this module is displayed",
+                trigger:
+                    "button[name='action_view_price_rules'] " +
+                    ".o_stat_text:contains(Price Rules)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 4 -- Click the Price Rules button.
+            {
+                content: "Click the Price Rules button",
+                trigger: "button[name='action_view_price_rules']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // -- Post-Condition -- the Price Rules list opens. The gate names
+            // the target action: before the click the active breadcrumb is the
+            // pricelist name, so it cannot match by mistake.
+            {
+                content: "Price Rules list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Price Rules)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_product/static/tests/tours/product_product_tour.js
+++ b/ssi_product/static/tests/tours/product_product_tour.js
@@ -1,0 +1,117 @@
+odoo.define("ssi_product.product_product_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/product_product/01-create.md
+    //
+    // "Product Varians" (product_product_menu) is a level-2 leaf menu, so it
+    // keeps its [data-menu-xmlid] and is a step of its own. The gate names the
+    // TARGET action, whose name is "Product Variants"; the app landing action
+    // is "Products", which does not contain that string, so the gate cannot
+    // pass on the previous screen.
+    //
+    // The variant form is product.product_normal_form_view, which inherits
+    // product.product_template_form_view — the Brand and Sequence fields this
+    // module adds there are therefore rendered on the variant form as well.
+    tour.register(
+        "ssi_product_product_product_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // -- Flow 1 -- Open the Product Varians menu; the list carries the
+            // drag handle and the Brand column added by this module.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Product & Pricelist app",
+                trigger: '.o_app[data-menu-xmlid="ssi_product.menu_root_product"]',
+            },
+            {
+                content: "Open the Product Varians menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.product_product_menu"]',
+            },
+            {
+                content: "Product Variants list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active" +
+                    ":contains(Product Variants)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+            {
+                content: "The Brand column added by this module is displayed",
+                trigger: ".o_list_view th:contains(Brand)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 2 -- Click the New button. (14.0: "Create")
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 3 -- Fill in Product Name, then the Brand and Sequence
+            // fields this module adds to the General Information tab.
+            {
+                content: "Fill in Product Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Product Variant",
+            },
+            {
+                content: "Type the brand name",
+                trigger: ".o_field_many2one[name='product_brand_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Brand Variant",
+            },
+            {
+                content: "Pick the brand from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR Brand Variant)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Sequence",
+                trigger: ".o_field_widget[name='sequence']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text 5",
+            },
+
+            // -- Flow 4 -- Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // -- Post-Condition -- the variant is saved and its Brand is shown
+            // on the form. The resulting ordering and the display name built by
+            // name_get are values, hence unit test territory.
+            {
+                content: "Record is saved and shows the Brand field",
+                trigger: ".o_form_view.o_form_readonly .o_form_label:contains(Brand)",
+                extra_trigger:
+                    ".o_control_panel .breadcrumb-item.active" +
+                    ":contains(TOUR Product Variant)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_product/static/tests/tours/product_template_tour.js
+++ b/ssi_product/static/tests/tours/product_template_tour.js
@@ -1,0 +1,111 @@
+odoo.define("ssi_product.product_template_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/product_template/01-create.md
+    //
+    // "Products" (product_template_menu) is a level-2 leaf menu, so it keeps
+    // its [data-menu-xmlid] and is a step of its own. It is also the landing
+    // action of the app, so the breadcrumb gate below is satisfied by the very
+    // action the step opens — there is no earlier screen it could match by
+    // mistake.
+    tour.register(
+        "ssi_product_product_template_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // -- Flow 1 -- Open the Products menu; the list carries the Brand
+            // column added by this module.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Product & Pricelist app",
+                trigger: '.o_app[data-menu-xmlid="ssi_product.menu_root_product"]',
+            },
+            {
+                content: "Open the Products menu",
+                trigger:
+                    ".o_menu_sections " +
+                    '[data-menu-xmlid="ssi_product.product_template_menu"]',
+            },
+            {
+                content: "Products list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Products)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+            {
+                content: "The Brand column added by this module is displayed",
+                trigger: ".o_list_view th:contains(Brand)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 2 -- Click the New button. (14.0: "Create")
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+
+            // -- Flow 3 -- Fill in Product Name, then the Brand and Sequence
+            // fields this module adds to the General Information tab.
+            {
+                content: "Fill in Product Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Product Template",
+            },
+            {
+                content: "Type the brand name",
+                trigger: ".o_field_many2one[name='product_brand_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR Brand Template",
+            },
+            {
+                content: "Pick the brand from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR Brand Template)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in Sequence",
+                trigger: ".o_field_widget[name='sequence']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text 5",
+            },
+
+            // -- Flow 4 -- Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // -- Post-Condition -- the product is saved and its Brand is shown
+            // on the form. Whether the brand is appended to the display name is
+            // a value, hence unit test territory, not a tour assertion.
+            {
+                content: "Record is saved and shows the Brand field",
+                trigger: ".o_form_view.o_form_readonly .o_form_label:contains(Brand)",
+                extra_trigger:
+                    ".o_control_panel .breadcrumb-item.active" +
+                    ":contains(TOUR Product Template)",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_product/tests/__init__.py
+++ b/ssi_product/tests/__init__.py
@@ -4,3 +4,7 @@
 
 from . import test_product_brand
 from . import test_ui_product_brand
+from . import test_ui_product_category
+from . import test_ui_product_pricelist
+from . import test_ui_product_product
+from . import test_ui_product_template

--- a/ssi_product/tests/test_ui_product_category.py
+++ b/ssi_product/tests/test_ui_product_category.py
@@ -1,0 +1,28 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — NOT HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiProductCategory(HttpSavepointCase):
+    """Tour test for the ``product.category`` work instruction."""
+
+    def test_create(self):
+        """Run the create tour for ``product.category``.
+
+        The tour needs no fixture: it creates the category through the UI,
+        and the only surface this module adds to the model is the
+        ``sequence`` field on that same form.
+
+        ``ssi_product.product_category_group`` already grants
+        ``base.user_root`` and ``base.user_admin`` membership in
+        ``security/res_group_data.xml``, so ``admin`` reaches the
+        Categories menu without any extra group setup.
+
+        IK: docs/product_category/01-create.md
+        """
+        self.start_tour("/web", "ssi_product_product_category_create", login="admin")

--- a/ssi_product/tests/test_ui_product_pricelist.py
+++ b/ssi_product/tests/test_ui_product_pricelist.py
@@ -1,0 +1,54 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — NOT HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiProductPricelist(HttpSavepointCase):
+    """Tour test for the ``product.pricelist`` work instruction."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the pricelist the tour opens, with one price rule.
+
+        The rule exists so the Price Rules button reports a non-empty
+        list; its value is never asserted by the tour.
+
+        ``ssi_product.pricelist_configurator_group`` already grants
+        ``base.user_root`` and ``base.user_admin`` membership in
+        ``security/res_group_data.xml``, so ``admin`` reaches the
+        Pricelists menu without any extra group setup.
+        """
+        super().setUpClass()
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {
+                "name": "TOUR Pricelist",
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "applied_on": "3_global",
+                            "compute_price": "fixed",
+                            "fixed_price": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_view_price_rules(self):
+        """Run the price rules tour for ``product.pricelist``.
+
+        The tour stops at the Price Rules list the button opens: which
+        rules that list holds is a value, so it stays in the unit tests.
+
+        IK: docs/product_pricelist/04-view-price-rules.md
+        """
+        self.start_tour(
+            "/web", "ssi_product_product_pricelist_view_price_rules", login="admin"
+        )

--- a/ssi_product/tests/test_ui_product_product.py
+++ b/ssi_product/tests/test_ui_product_product.py
@@ -1,0 +1,46 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — NOT HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiProductProduct(HttpSavepointCase):
+    """Tour test for the ``product.product`` work instruction."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the brand the create tour selects on the variant form.
+
+        ``ssi_product.product_configurator_group`` already grants
+        ``base.user_root`` and ``base.user_admin`` membership in
+        ``security/res_group_data.xml``, so ``admin`` reaches the Product
+        Varians menu without any extra group setup.
+
+        ``note`` is filled deliberately: the brand kanban card renders
+        ``record.note.value.substr(0, 200)``, and 14.0 leaves
+        ``record.note.value`` undefined when the field is empty.
+        """
+        super().setUpClass()
+        cls.brand = cls.env["product.brand"].create(
+            {
+                "name": "TOUR Brand Variant",
+                "code": "/",
+                "note": "Tour fixture for the product variant work instruction.",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``product.product``.
+
+        The tour asserts the Brand column, the Brand field, and the
+        Sequence field this module adds to the variant surfaces. The
+        resulting record order and the display name built by ``name_get``
+        are values, so they stay in the unit tests.
+
+        IK: docs/product_product/01-create.md
+        """
+        self.start_tour("/web", "ssi_product_product_product_create", login="admin")

--- a/ssi_product/tests/test_ui_product_template.py
+++ b/ssi_product/tests/test_ui_product_template.py
@@ -1,0 +1,46 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — NOT HttpCase. 14.0's HttpCase has no cls.env in
+# setUpClass (see odoo-development-ui-test skill, structure-and-runner.md).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiProductTemplate(HttpSavepointCase):
+    """Tour test for the ``product.template`` work instruction."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the brand the create tour selects on the product form.
+
+        ``ssi_product.product_configurator_group`` already grants
+        ``base.user_root`` and ``base.user_admin`` membership in
+        ``security/res_group_data.xml``, so ``admin`` reaches the Products
+        menu without any extra group setup.
+
+        ``note`` is filled deliberately: the brand kanban card renders
+        ``record.note.value.substr(0, 200)``, and 14.0 leaves
+        ``record.note.value`` undefined when the field is empty.
+        """
+        super().setUpClass()
+        cls.brand = cls.env["product.brand"].create(
+            {
+                "name": "TOUR Brand Template",
+                "code": "/",
+                "note": "Tour fixture for the product template work instruction.",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``product.template``.
+
+        The tour asserts the Brand column, the Brand field, and the
+        Sequence field this module adds. Whether ``name_get`` appends the
+        brand to the display name is a value, so it stays in
+        ``tests/test_data_product_brand.yaml``.
+
+        IK: docs/product_template/01-create.md
+        """
+        self.start_tour("/web", "ssi_product_product_template_create", login="admin")

--- a/ssi_product/views/assets.xml
+++ b/ssi_product/views/assets.xml
@@ -13,6 +13,22 @@
                 type="text/javascript"
                 src="/ssi_product/static/tests/tours/product_brand_tour.js"
             />
+        <script
+                type="text/javascript"
+                src="/ssi_product/static/tests/tours/product_category_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_product/static/tests/tours/product_pricelist_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_product/static/tests/tours/product_product_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_product/static/tests/tours/product_template_tour.js"
+            />
     </xpath>
 </template>
 </odoo>


### PR DESCRIPTION
Closes #31

## Ringkasan

Menambahkan Instruksi Kerja (IK) extension beserta tour pasangannya untuk empat model
inti yang di-extend `ssi_product`. IK hanya mendokumentasikan field & tombol yang
ditambahkan modul ini — perilaku bawaan Odoo tidak ditulis ulang.

| Model | Berkas IK | Tour |
|---|---|---|
| `product.category` | `docs/product_category/01-create.md` | `ssi_product_product_category_create` |
| `product.template` | `docs/product_template/01-create.md` | `ssi_product_product_template_create` |
| `product.product` | `docs/product_product/01-create.md` | `ssi_product_product_product_create` |
| `product.pricelist` | `docs/product_pricelist/04-view-price-rules.md` | `ssi_product_product_pricelist_view_price_rules` |

- IK `product.pricelist` memuat langkah menekan tombol `action_view_price_rules`, dan
  tour-nya mengkliknya lalu memverifikasi list **Price Rules** terbuka.
- Tour memakai API legacy 14.0 (`odoo.define` + `tour.register`), didaftarkan ke bundle
  `web.assets_tests` lewat `views/assets.xml`; pemanggilnya `HttpSavepointCase`.
- Tidak ada assertion nilai di tour (nilai `name_get`, urutan record, dan hitungan rule
  tetap wilayah unit test).

## Verifikasi

```
#GATE repo=ssi-product-attribute modules=1 failed=0 skipped=0 status=OK
#VALIDATOR name=ik target=.../ssi_product series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=.../ssi_product series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Peringatan `aksi bertombol tanpa rumah di docs/: action_view_price_rules` yang ada
sebelum PR ini sudah hilang.